### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:lts-alpine AS build
 WORKDIR /app
-COPY package.json package-lock.json .
+COPY package.json package-lock.json ./
 RUN npm ci
 COPY . .
 RUN npm run build && npm ci --prod
@@ -10,7 +10,7 @@ WORKDIR /app
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/build ./build
 COPY --from=build /app/svelte.config.js .
-COPY --from=build /app/package.json .
+COPY --from=build /app/package.json ./
 
 ENV PORT=3000
 CMD [ "node", "./build" ]


### PR DESCRIPTION
On newer versions of Docker you need to add the trailing slash in order to build. Otherwise build will fail with this error code: 

Step 3/14 : COPY package.json package-lock.json .
When using COPY with more than one source file, the destination must be a directory and end with a /
ERROR: Service 'app' failed to build : Build failed

Tested working with Docker Version:  Docker version 20.10.11, build dea9396